### PR TITLE
fix: preserve decimal scale values in dimension names

### DIFF
--- a/Verify_Drawing_Redecam/Drawing.py
+++ b/Verify_Drawing_Redecam/Drawing.py
@@ -543,10 +543,11 @@ class Drawing:
         layer_default = '0'
 
         scale = self.subtitle_block['x_scale']
-        scale_str = str(int(scale)) if scale.is_integer() else str(scale)
 
-        dimension_metric_default = f'1-{scale_str}'
-        dimension_inch_default = f'1-{scale_str}_USA'
+        dimension_metric_default = f'1-{scale}'
+        dimension_inch_default = f'1-{scale}_USA'
+
+        print(dimension_inch_default , dimension_metric_default)
 
         if self.doc_dxf.header["$CLAYER"] != layer_default:
             self.error_drawing.er31['boolean_value'] = True


### PR DESCRIPTION
Em que escalas de cota com valores decimais (ex.: 1-2.5) eram arredondadas e geradas incorretamente como escalas inteiras (ex.: 1-2).

Agora os valores decimais são preservados, removendo apenas o .0 quando o valor for inteiro.